### PR TITLE
Added edge annotations

### DIFF
--- a/daft.py
+++ b/daft.py
@@ -93,8 +93,7 @@ class PGM(object):
         if directed is None:
             directed = self._ctx.directed
 
-        e = Edge(self._nodes[name1], self._nodes[name2], directed=directed,
-                **kwargs)
+        e = Edge(self._nodes[name1], self._nodes[name2], directed=directed, plot_params=kwargs)
         self._edges.append(e)
 
         return e
@@ -374,6 +373,13 @@ class Edge(object):
         p = self.plot_params
         p["linewidth"] = _pop_multiple(p, ctx.line_width,
                                         "lw", "linewidth")
+
+        # annotate
+        if self.plot_params.has_key('label'):
+            x, y, dx, dy = self._get_coords(ctx)
+            ax.annotate(self.plot_params['label'], [x+dx/2, y+dy/2], xycoords="data", 
+                        xytext=[0, 3], textcoords="offset points",
+                        ha="center", va="center")
 
         if self.directed:
             p["ec"] = _pop_multiple(p, "k", "ec", "edgecolor")


### PR DESCRIPTION
I know it's not strictly speaking part of the PGM notation but I added edge notations so I could use Daft for some other stuff too. Text offset is hard coded so might not resize well. It was a bit beyond my Matplotlib skills to figure this out....

```
from matplotlib import rc
rc("font", family="serif", size=20)
rc("text", usetex=True)

import daft

pgm = daft.PGM([6.0, 5.0], grid_unit=4, node_unit=2, line_width=1.5, origin=[0.5, 0])

# Nodes
pgm.add_node(daft.Node("i", r"$i$", 1.0, 3))

pgm.add_node(daft.Node("i2", r"$i$", 3, 4))
pgm.add_node(daft.Node("j", r"$j$", 3, 3))
pgm.add_node(daft.Node("k", r"$k$", 3, 2))

pgm.add_node(daft.Node("j2", r"$j$", 5, 3))

# Edges
pgm.add_edge("i", "i2", label=r"$p_{ii}^{(t)}$")
pgm.add_edge("i", "j", label=r"$p_{ij}^{(t)}$")
pgm.add_edge("i", "k", label=r"$p_{ik}^{(t)}$")
pgm.add_edge("i2", "j2", label=r"$p_{ij}^{(t+1)}$")
pgm.add_edge("j", "j2", label=r"$p_{jj}^{(t+1)}$")
pgm.add_edge("k", "j2", label=r"$p_{kj}^{(t+1)}$")

# Plates
pgm.add_plate(daft.Plate([0.5, 1.5, 1, 3], label=r"$t$", label_offset=[0.5, 0.5],  shift=-0.1))
pgm.add_plate(daft.Plate([2.5, 1.5, 1, 3], label=r"$t+1$", label_offset=[0.5, 0.5],   shift=-0.1))
pgm.add_plate(daft.Plate([4.5, 1.5, 1, 3], label=r"$t+2$", label_offset=[0.5, 0.5], shift=-0.1))

# Render
pgm.render()
```

![daft_edges](https://f.cloud.github.com/assets/771107/238366/aa1aaeaa-8834-11e2-86c1-9fbe1d09a117.png)
