### PR TITLE
Labels on the Plate object are no longer blue

### DIFF
--- a/daft.py
+++ b/daft.py
@@ -543,9 +543,14 @@ class Plate(object):
         A dictionary of parameters to pass to the
         :class:`matplotlib.patches.Rectangle` constructor.
 
+    :param bbox: (optional)
+        A dictionary of parameters to pass to the 
+        :class:`matplotlib.axes.Axes.annotate` function.
+
     """
     def __init__(self, rect, label=None, label_offset=[5, 5], shift=0,
-                 position="bottom left", rect_params=None, bbox=None):
+                 position="bottom left", rect_params=None,
+                 bbox=None):
         self.rect = rect
         self.label = label
         self.label_offset = label_offset
@@ -557,7 +562,7 @@ class Plate(object):
         if bbox is not None:
             self.bbox = dict(bbox)
         else:
-            self.bbox = None
+            self.bbox = {"color": "none"}
         self.position = position
 
     def render(self, ctx):

--- a/daft.py
+++ b/daft.py
@@ -545,7 +545,7 @@ class Plate(object):
 
     :param bbox: (optional)
         A dictionary of parameters to pass to the 
-        :class:`matplotlib.axes.Axes.annotate` function.
+        `matplotlib.axes.Axes.annotate` function.
 
     """
     def __init__(self, rect, label=None, label_offset=[5, 5], shift=0,

--- a/daft.py
+++ b/daft.py
@@ -549,8 +549,7 @@ class Plate(object):
 
     """
     def __init__(self, rect, label=None, label_offset=[5, 5], shift=0,
-                 position="bottom left", rect_params=None,
-                 bbox=None):
+                 position="bottom left", rect_params=None, bbox=None):
         self.rect = rect
         self.label = label
         self.label_offset = label_offset


### PR DESCRIPTION
This PR fixes the closed issue #102 by making the `bbox` dictionary used to color the label in the `Plate` object have `color` set to `none`. Also, this argument did not have a docstring previously, and that has now been added. If you want, you can move the default setting into the function signature.