### PR TITLE
clf for reset figure

### DIFF
--- a/daft.py
+++ b/daft.py
@@ -1226,8 +1226,8 @@ class _rendering_context(object):
 
     def reset_figure(self):
         if self._figure is not None:
-            plt.close(self._figure)
-            self._figure = None
+            # Clear the figure but keep the memory allocated for efficiency
+            self._figure.clf()
             self._ax = None
 
     def figure(self):


### PR DESCRIPTION
Support to clear figure instead of closing it for `reset_figure`.

This also enables better efficiency since we are not de-allocating and re-allocating memory each time.